### PR TITLE
API : sample items

### DIFF
--- a/APIs.md
+++ b/APIs.md
@@ -1,0 +1,34 @@
+# Useful API s
+
+## データ取得
+
+* [国会図書館サーチ検索用 api](http://iss.ndl.go.jp/information/api/)
+  - Provider : 国会図書館
+  - Registration_required : required for commercial use
+  - Data_Format : [xml]
+  - SDKs_provided : []
+* [国会図書館サーチハーベスト用 api](http://iss.ndl.go.jp/information/api/)
+  - Provider : 国会図書館
+  - Registration_required : required for commercial use
+  - Data_Format : [xml]
+  - SDKs_provided : []
+  - Note : メタデータのダウンロード
+
+## テキスト処理系
+
+* [雑談対話api](https://dev.smt.docomo.ne.jp/?p=docs.api.page&api_name=dialogue&p_name=api_usage_scenario)
+  - Provider : docomo
+  - Registration_required : true
+  - Data_Format : [json]
+  - SDKs_provided : [Android, iOS, Java]
+* [日本語形態素解析](http://developer.yahoo.co.jp/webapi/jlp/ma/v1/parse.html)
+  - Provider : yahoo
+  - Registration_required : true
+  - Data_Format : [xml]
+
+
+## Providers
+
+* [e-Stat](http://www.e-stat.go.jp/api/)
+* [Yahoo! デベロッパーネットワーク](http://developer.yahoo.co.jp/)
+* [docomo Developer support](https://dev.smt.docomo.ne.jp/?p=index)


### PR DESCRIPTION
こういう感じで，使えそうな/面白そうな api もためていくのはどうかという提案．Providers のところは，「いちいち api をリストアップすると収拾つかなくなるけど，ここが色々 api を提供してるよ」という意図です．

項目が多くなるだろうのと，時々で色々な項目で sort したくなるような気もするので， json などの形式でデータを書いて， html+javascript で読む方がいいかも知れません．
